### PR TITLE
ADR 0001 - Use ADRs for Review

### DIFF
--- a/DHCW/TDA/adr-0001-use-adrs-in-github.md
+++ b/DHCW/TDA/adr-0001-use-adrs-in-github.md
@@ -1,0 +1,108 @@
+# 0001 - Use Architectural Decision Records
+
+**Status**: proposed  
+**Date**: 2025-03-17  
+**Governance**: Drafted for DHCW Technical Design Authority (TDA) for approval
+
+## Situation - Context and Problem Statement
+
+* We want to record architecture related decisions for NHS Wales organisations, made via agreed governance mechanisms. 
+* We need to agree the **structure** of the records i.e what information a record should contain.
+
+## Background - Decision Drivers
+* We want the structure to support both detailed and lightweight records.
+* We want to align with industry standards (not reinvent the wheel).
+* We want the selected structure to be easily adopted.
+
+## Assessment - Considered Options
+The structure utilised by:
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
+* [Decision record template by Jeff Tyree and Art Akerman](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-jeff-tyree-and-art-akerman) - Used in CapitalOne (regulated industry)
+* Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
+* [SBAR](https://en.wikipedia.org/wiki/SBAR) (Situation, Background, Assessment, Recommendation) template - used by DHCW internally and in healthcare generally.
+* Formless – No conventions for structure
+
+## Recommendation - Decision Outcome
+
+Adopt an ADR structure with mandatory and optional fields,  taking elements of MADR and aligning it with the existing SBAR structure.
+
+* Allows for structured capturing of any decision.
+* The structure is comprehensible and facilitates usage & maintenance.
+* It allows varying levels of detail to suit the decision being made.
+* Aligns with existing terminology and structure that teams will be familar with.  
+* The structure enables flexiblility in format, storage and publishing.
+
+<br/>
+
+# ADR Template
+The below template forms the structure of an ADR.
+
+**Status**: {proposed | rejected | accepted | deprecated | superseded by ADR-0123}  
+**Date**: {YYYY-MM-DD when the decision was last updated}  
+**Governance**: {describe the governance involved in the decision e.g. Technical Design Authority  approved}  
+
+# {short title, representative of solved problem and found solution}
+
+## Situation - Context and Problem Statement
+
+{Describe the situation, what is the context and problem statement, e.g., in free form using two to three sentences or in the form of an illustrative story.}
+
+## Background - Decision Drivers (Optional)
+
+{Optionally describe the background to the situation, what are the factors are driving the decision}
+
+* {decision driver 1, e.g., a force, facing concern, …}
+* {decision driver 2, e.g., a force, facing concern, …}
+* … <!-- numbers of drivers can vary -->
+
+## Assessment - Considered Options
+
+{List briefly the options that have been considered}
+
+* {title of option 1}
+* {title of option 2}
+* {title of option 3}
+* … <!-- numbers of options can vary -->
+
+## Recommendation - Decision Outcome
+
+{Describe the chosen option and justification}.
+
+### Consequences (Optional)
+
+* Good, because {positive consequence, e.g., improvement of one or more desired qualities, …}
+* Bad, because {negative consequence, e.g., compromising one or more desired qualities, …}
+* … <!-- numbers of consequences can vary -->
+
+### Confirmation (Optional)
+
+{Describe how the implementation of/compliance with the ADR can/will be confirmed.}
+
+## Pros and Cons of the Options (Optional)
+
+### {title of option 1}
+
+<!-- This is an optional element. Feel free to remove. -->
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+<!-- use "neutral" if the given argument weights neither for good nor bad -->
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* … <!-- numbers of pros and cons can vary -->
+
+### {title of other option}
+
+{example | description | pointer to more information | …}
+
+* Good, because {argument a}
+* Good, because {argument b}
+* Neutral, because {argument c}
+* Bad, because {argument d}
+* …
+
+## More Information (Optional)
+
+{You might want to provide additional evidence/confidence for the decision outcome here and/or document the team agreement on the decision and/or define when/how this decision the decision should be realised and if/when it should be re-visited. Links to other decisions and resources might appear here as well.}


### PR DESCRIPTION
## Description
Add ADR 0001 - decision to use architectural decision records. 

## Related 
A separate ADR will be created for where to store and how to publish ADRs

## Motivation and Context
As presented and discussed at the DHCW Technical Design Authority (TDA) on March 7th 2025, there is a desire to adopt lightweight records for architecture related decisions; the propose was to review MADR and related ADRs which was well received by the TDA. This PR creates the first ADR, which is the decision to use ADRs and adopt an appropriate template.

## How to review
* Review the proposed initial storage structure (DHCW/TDA/####-adr-....)
* Review the contents of the first ADR (0001)
* Check the Markdown used is correct