### PR TITLE
Revise Architecture Decision Record naming conventions

### DIFF
--- a/DHCW/TDA/adr-architecture-decision-records-naming-conventions.md
+++ b/DHCW/TDA/adr-architecture-decision-records-naming-conventions.md
@@ -1,7 +1,7 @@
-# ADR - Architecture Decision Records Naming Convention
+# Architecture Decision Records Naming Convention
 
 **Status**: proposed  
-**Date**: 2025-03-24  
+**Date**: 2025-03-25  
 **Governance**: Drafted for DHCW Technical Design Authority (TDA) for approval
 
 ## Situation - Context and Problem Statement
@@ -14,56 +14,65 @@
 We want:
 * a consistent naming convention for our decisions.
 * names to be human readable and easy to understand.
-* to be able to cross-reference ADRs easily.
-* the naming to support multiple ADRs being developed in parallel (i.e. avoid naming clashes).
+* to be able to cross-reference Architecture Decision Records easily.
+* the naming to support multiple Architecture Decision Records being developed in parallel (i.e. avoid naming clashes).
 
 ## Assessment - Considered Options
 
 For naming itself:
 * Just sequential numbering e.g. ADR 0001, ADR 0002, ...
-* Sequential numbering and titles e.g. ADR 0001 - ADR-0001-Title, ADR 0002 - Title, ...
-* Just titles e.g. ADR - Title, ADR - Title
+* Sequential numbering and titles e.g. ADR 0001 - Title, ADR 0002 - Title, ...
+* Just titles e.g. "Title of a Record"
 * Formless – No naming convention - author's choice.
 
 For filenames:
-* The title of the ADR as above as-is e.g. ``ADR - Title Goes Here.md``
-* Use of lowercase 'kebab' style for filenames e.g. ``adr-title-goes-here.md``
-* Use of lowercase 'snake' style for filenames e.g. ``adr_title_goes_here.md``
+* The title of the Architecture Decision Record as above as-is e.g. ``Title Goes Here.md``
+* Use of lowercase 'kebab' style for filenames e.g. ``title-goes-here.md``
+* Use of lowercase 'snake' style for filenames e.g. ``title_goes_here.md``
+
+On acronyms:
+* Use 'ADR' as an acronym for Architecture Decision Record.
+* Avoid acronyms, e.g. always spell out "Architecture Decision Record" in full.
 
 ## Recommendation - Decision Outcome
-### Naming Convention
-Adopt an ADR **naming convention** of:
-* Just titles, in Title Case, prefixed by **'ADR - '**.
+### Naming Conventions
+Adopt an Architecture Decision Record **naming convention** of:
+* Just titles, in Title Case
 * Author to ensure the title makes it clear what the decision relates to.
 * Author to ensure titles are human readable and unique.
+* Avoid the use of acronyms
 * Examples:
-    * 'ADR - Use Architecture Decision Records and Structure'
-    * 'ADR - Architecture Decision Records Naming Convention'
-    * 'ADR - Architecture Decision Record Format as Markdown'
+    * 'Use Architecture Decision Records and Structure'
+    * 'Architecture Decision Records Naming Conventions'
+    * 'Format Architecture Decision Records with Markdown'
 
-Whilst numbering ADRs makes them easy to cross-reference, it introduces an administrative/process overhead to ensure numbers are unique and sequential and adds complexity in the ordering of ADRs, especially when multiple ADRs are in development in parallel (which gets published first, who gets the next ADR number etc.). 
+Whilst numbering Architecture Decision Records makes them easy to cross-reference, it introduces an administrative/process overhead to ensure numbers are unique and sequential and adds complexity in the ordering of records, especially when multiple records are in development in parallel (which gets published first, who gets the next record number etc.). 
 
-Using human readable names makes them easy to refer to and talk about.
+Avoiding acronyms and using human readable names makes them easier for users to understand, refer to and talk about.
 
-**Note:** We are referring to ADRs as '_Architecture_' decision records, not '_Architectural_' or other similar titles.
+**Note:** We are referring to '**_Architecture_**' decision records, not '_Architectural_' or other similar words.
+
+**Note:** Readability is important, it may be better to refer to Architecture Decision Records as _decisions_ and _records_ in documents rather than always writing out the full _Architecture Decision Records_ every time e.g. 
+* "This **_record_** builds on the previous **_decision_**" (good - emphasis only added here for clarity).
+* "This _Architecture Decision Record_ builds on the previous _Architecture Decision Record_" (worse/avoid). 
 
 ### Filenames
-Given the above, apply the following convention to **filenames**: Match the Title of the ADR and remove whitespace and adopt kebab style e.g. 
-* ``adr-architecture-decision-records-naming-convention.md``
-* ``adr-use-architecture-decision-records-and-structure.md``
-* ``adr-specify-adr-format-as-markdown.md``
+Given the above, apply the following convention to **filenames**: Match the Title of the record and remove whitespace and adopt kebab style e.g. 
+* ``architecture-decision-records-naming-conventions.md``
+* ``use-architecture-decision-records-and-structure.md``
+* ``format-architecture-decision-records-with-markdown.md``
 
 ### Cross Referencing
-When cross-referencing ADRs, use the full title of the ADR and link to the record filename itself e.g.
-* See [ADR - Architecture Decision Records Naming Convention](adr-architecture-decision-records-naming-conventions.md)
+When cross-referencing decisions, use the full title of the decision and link to the record filename itself e.g.
+* See [Architecture Decision Records Naming Conventions](adr-architecture-decision-records-naming-conventions.md)
 
 ### Branches
-Git branch names should utilise the same convention as the main filename of the ADR itself e.g.
-* ``git checkout -m adr-architecture-decision-records-naming-convention``
+Git branch names should utilise the same convention as the main filename of the decision itself e.g.
+* ``git checkout -m architecture-decision-records-naming-conventions``
 
 ### Confirmation
 
-This ADR will be enforced by reviewers of newly submitted ADRs, who should refer to this ADR and confirm the naming convention and decision herein is being adhered to.
+This decision will be enforced by reviewers of newly submitted records, who should refer to this decision and confirm the naming convention and decision herein is being adhered to.
 
 ## More Information (Optional)
-See [ADR - Use Architecture Decision Records and Structure](adr-use-architecture-decision-records-and-structure.md) for the structure of ADRs
+See [Use Architecture Decision Records and Structure](adr-use-architecture-decision-records-and-structure.md) for the structure of records.

--- a/DHCW/TDA/architecture-decision-records-naming-conventions.md
+++ b/DHCW/TDA/architecture-decision-records-naming-conventions.md
@@ -64,7 +64,7 @@ Given the above, apply the following convention to **filenames**: Match the Titl
 
 ### Cross Referencing
 When cross-referencing decisions, use the full title of the decision and link to the record filename itself e.g.
-* See [Architecture Decision Records Naming Conventions](adr-architecture-decision-records-naming-conventions.md)
+* See [Architecture Decision Records Naming Conventions](architecture-decision-records-naming-conventions.md)
 
 ### Branches
 Git branch names should utilise the same convention as the main filename of the decision itself e.g.
@@ -75,4 +75,4 @@ Git branch names should utilise the same convention as the main filename of the 
 This decision will be enforced by reviewers of newly submitted records, who should refer to this decision and confirm the naming convention and decision herein is being adhered to.
 
 ## More Information (Optional)
-See [Use Architecture Decision Records and Structure](adr-use-architecture-decision-records-and-structure.md) for the structure of records.
+See [Use Architecture Decision Records and Structure](use-architecture-decision-records-and-structure.md) for the structure of records.

--- a/DHCW/TDA/format-architecture-decision-records-with-markdown.md
+++ b/DHCW/TDA/format-architecture-decision-records-with-markdown.md
@@ -1,4 +1,4 @@
-# ADR - Format ADRs using plaintext Markdown
+# Format Architecture Decision Records using plaintext Markdown
 
 **Status**: proposed  
 **Date**: 2025-03-25  
@@ -7,14 +7,14 @@
 ## Situation - Context and Problem Statement
 
 * We want to record architecture related decisions for NHS Wales organisations, made via agreed governance mechanisms. 
-* The **structure** is decided by [ADR - Use Architecture Decision Records](adr-use-architecture-decision-records-and-structure.md)
+* The **structure** is decided by [Use Architecture Decision Records](use-architecture-decision-records-and-structure.md)
 * We need to agree the **format**.
 
 ## Background - Decision Drivers
 
 * We want the format to be simple and easy to publish on the internet.
 * We want the format to support 'formatting' e.g. headings, bold, italics, lists.
-* We don't want any proprietory tools to be required to contribute ADRs.
+* We don't want any proprietary tools to be required to contribute Architecture Decision Records.
 * We want to align with industry standards (not reinvent the wheel).
 * We want the selected format to be easily adopted.
 
@@ -22,14 +22,14 @@
 
 * [Markdown](https://commonmark.org/)
 * [Microsoft DOCX](https://en.wikipedia.org/wiki/Microsoft_Office_Open_XML)
-* [Open Document] (https://en.wikipedia.org/wiki/OpenDocument_technical_specification)
+* [Open Document](https://en.wikipedia.org/wiki/OpenDocument_technical_specification)
 * No format – just plaintext
 
 ## Recommendation - Decision Outcome
 
-Format ADRs as plaintext Markdown documents, using the CommonMark specification.
+Format Architecture Decision Records as plaintext Markdown documents, using the CommonMark specification.
 
-* Allows for ADRs to be created and edited in any text editor, no specific software needed.
+* Allows for Architecture Decision Records to be created and edited in any text editor, no specific software needed.
 * Markdown is easy to learn.
 * Markdown supports the basic formatting we need (bold, italics, headings, lists etc.) 
 * Due to the limitations, it guides us to keep things simple (KISS) and easy to read.
@@ -41,4 +41,4 @@ Format ADRs as plaintext Markdown documents, using the CommonMark specification.
 * Markdown limits the formatting of the document (can be seen as a positive) so users may be constrained in presenting information.
 
 ## More Information
-See [ADR - Use Architecture Decision Records](adr-use-architecture-decision-records-and-structure.md) for the structure of an ADR.
+See [Use Architecture Decision Records and Structure](use-architecture-decision-records-and-structure.md) for the structure of an Architecture Decision Record.

--- a/DHCW/TDA/use-architecture-decision-records-and-structure.md
+++ b/DHCW/TDA/use-architecture-decision-records-and-structure.md
@@ -1,4 +1,4 @@
-# ADR - Use Architecture Decision Records
+# Use Architecture Decision Records and Structure
 
 **Status**: proposed  
 **Date**: 2025-03-25  
@@ -16,7 +16,7 @@
 
 ## Assessment - Considered Options
 The structure utilised by:
-* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "ADR"
+* [Michael Nygard's template](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions) – The first incarnation of the term "Architecture Decision Records" (ADR)
 * [MADR](https://adr.github.io/madr/) 4.0.0 – The Markdown Architectural Decision Records
 * [Decision record template by Jeff Tyree and Art Akerman](https://github.com/joelparkerhenderson/architecture-decision-record/tree/main/locales/en/templates/decision-record-template-by-jeff-tyree-and-art-akerman) - Used in CapitalOne (regulated industry)
 * Other templates listed at <https://github.com/joelparkerhenderson/architecture_decision_record>
@@ -25,24 +25,24 @@ The structure utilised by:
 
 ## Recommendation - Decision Outcome
 
-Adopt an ADR structure with mandatory and optional fields,  taking elements of MADR and aligning it with the existing SBAR structure.
+Adopt an Architecture Decision Record structure with mandatory and optional fields,  taking elements of MADR and aligning it with the existing SBAR structure.
 
 * Allows for structured capturing of any decision.
 * The structure is comprehensible and facilitates usage & maintenance.
 * It allows varying levels of detail to suit the decision being made.
-* Aligns with existing terminology and structure that teams will be familar with.  
-* The structure enables flexiblility in format, storage and publishing.
+* Aligns with existing terminology and structure that teams will be familiar with.  
+* The structure enables flexibility in format, storage and publishing.
 
 <br/>
 
-# ADR Template
-The below template forms the structure of an ADR.
+# Architecture Decision Record Template
+The below template forms the structure of an Architecture Decision Record.
 
-**Status**: {proposed | rejected | accepted | deprecated | superseded by ADR-...}  
+**Status**: {proposed | rejected | accepted | deprecated | superseded by ABC...}  
 **Date**: {YYYY-MM-DD when the decision was last updated}  
 **Governance**: {describe the governance involved in the decision e.g. Technical Design Authority  approved}  
 
-# ADR - {short title, representative of solved problem and found solution}
+# {short title, representative of solved problem and found solution}
 
 ## Situation - Context and Problem Statement
 
@@ -77,7 +77,7 @@ The below template forms the structure of an ADR.
 
 ### Confirmation (Optional)
 
-{Describe how the implementation of/compliance with the ADR can/will be confirmed.}
+{Describe how the implementation of/compliance with the Architecture Decision Record can/will be confirmed.}
 
 ## Pros and Cons of the Options (Optional)
 


### PR DESCRIPTION
## Description
After further discussion some changes to the naming convention are being proposed to make records easier to read and refer to etc.

## Related
#4 for the previous PR on naming conventions
 
## Motivation and Context
* Removes acronyms (e.g. ADR) and clarifies how to refer to records to improve readability and access for new users.

## How to review
* Review the proposed updates to the naming conventions, do these improve readability and make it easier for new users to engage?
* Check the Markdown is correct and links work