### PR TITLE
Add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,45 @@
+##
+# all: do all the typical steps.
+##
+.PHONY: all
+all: install sync run ;
+
+##
+# help: display this help message.
+##
+.PHONY: help
+help:
+	@awk '/^##/{a=1-a}a' $(MAKEFILE_LIST) | cut -c3-
+
+##
+# install: install any project aspects; this will install the command `uv`.
+##
+.PHONY: install
+install: 
+	curl -LsSf https://astral.sh/uv/install.sh | sh
+	@echo "The uv command should now be installed and available."
+
+##
+# sync: synchronize the project aspects; this will run the command `uv sync`.
+##
+.PHONY: sync
+sync: 
+	uv sync
+	@echo "The uv command should now be synchronized and configured."
+
+##
+# run: run the project aspects; this will launch the documentation server.
+##
+.PHONY: run
+run: 
+	uv run mkdocs serve
+	@echo "The documentation should now be available by browsing http://127.0.0.1:8000/"
+
+##
+# newline: display a newline character so we can print prettier messages.
+##
+.PHONY: newline
+define newline
+
+
+endef

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To see options for the command `make`:
 make help
 ```
 
+To do everything to build the documentation and run it:
+
+```sh
+make
+```
+
 ### Building docs manually
 
 Install 'uv' for Python package/env management e.g. :

--- a/README.md
+++ b/README.md
@@ -1,8 +1,28 @@
 # GIG Cymru NHS Wales - Architecture Decision Records
 
-## Building Docs
+An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
 
-**WIP**: Publishing our records using a [Mkdoc Material](https://squidfunk.github.io/mkdocs-material/) site
+## Introduction
+
+* [Why write architecture decision records - By GitHub Engineering](https://github.blog/engineering/architecture-optimization/why-write-adrs/)
+
+* [A practical overview on Architecture Decision Records: How to start and why this could be your most valuable action as a software architect](https://ctaverna.github.io/adr/)
+
+## Documentation
+
+Our records are published using [Mkdoc Material](https://squidfunk.github.io/mkdocs-material/).
+
+### Building Docs with Make
+
+If you are a developer, or you want to generate documentation on your own system, then you can use the command `make`.
+
+To see options for the command `make`:
+
+```sh
+make help
+```
+
+### Building Docs Manually
 
 Install 'uv' for Python package/env management e.g. :
 
@@ -23,3 +43,7 @@ uv run mkdocs serve
 ```
 
 Navigate to ``http://127.0.0.1:8000/``
+
+## License
+
+This repository is licensed under the [MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 
 Our records are published using [Mkdoc Material](https://squidfunk.github.io/mkdocs-material/).
 
-### Building Docs with Make
+### Building docs with make
 
 If you are a developer, or you want to generate documentation on your own system, then you can use the command `make`.
 
@@ -22,7 +22,7 @@ To see options for the command `make`:
 make help
 ```
 
-### Building Docs Manually
+### Building docs manually
 
 Install 'uv' for Python package/env management e.g. :
 


### PR DESCRIPTION
Add Makefile that's able to install uv, run uv sync, then launch the documentation server.

## Description

See the Makefile for specifics.

## Related

This Makefile won't do much (other than error) until the documentation branch is merged too.

## Motivation and Context

Infrastructure as code.

## How to review

Merge the documentation branch, then run:

```sh
make
```

And also run:


```sh
make help
```
