### PR TITLE
Add United Kingdom National Cyber Security Center guidance

### DIFF
--- a/doc/united-kingdom-national-cyber-security-centre/index.md
+++ b/doc/united-kingdom-national-cyber-security-centre/index.md
@@ -1,8 +1,8 @@
-# United Kingom (UK) National Cyber Security Centre (NCSC)
+# United Kingdom (UK) National Cyber Security Centre (NCSC)
 
 **Status**: first sketch, work in progress, request for collaboration
 
-**Date**: 2025-03-27
+**Date**: Updated 2025-04-04
 
 **Governance**: To Be Discovered; potentially a combo of this repo participants, UK NHS Wales DHCW CISO, UK NHS Wales UCB peers, etc.
 
@@ -24,26 +24,25 @@ Alex describes that UK NCSC is advisory-only, not regulatory. Joel is currently 
 
 Alex at NCSC has suggested multiple options for us to consider:
 
-1. NCSC can provide a cyber-security assessment of our organisation, which we can then use to improve our cyber-security practices. Alex is going to send along more information about how this would work. There's extensive information on the NCSC website about this.
+* \1. NCSC can provide a cyber-security assessment of our organisation, which we can then use to improve our cyber-security practices. Alex is going to send along more information about how this would work. There's extensive information on the NCSC website about this.
 
-1.a. NCSC can do this with each NHS Wales group separately.
+* \1.a. NCSC can do this with each NHS Wales group separately.
 
-1.b. NCSC can do this with all the NHS Wales groups all together.
+* \1.b. NCSC can do this with all the NHS Wales groups all together.
 
-2. In parallel, NHS Wales staff (e.g. Joel, Chris, etc.) can join the NCSC, in variuos ways.
+* \2. In parallel, NHS Wales staff (e.g. Joel, Chris, etc.) can join the NCSC, in variuos ways.
 
-2.a. NCSC Slack channel, which involves 300+ security-related people who are advising the teams, requesting features, reporting issues, etc.
+* \2.a. NCSC Slack channel, which involves 300+ security-related people who are advising the teams, requesting features, reporting issues, etc.
 
-2.b. NCSC planning-- unclear what this means-- need more info; it sounds somewhat like UK Government Design System team.
+* \2.b. NCSC planning-- unclear what this means-- need more info; it sounds somewhat like UK Government Design System team.
 
-3. NCSC has change management processes where DHCW (e.g. Joel, Chris, CISO, etc.) can request changes to the NCSC programs, in order of priority.
+* \3. NCSC has change management processes where DHCW (e.g. Joel, Chris, CISO, etc.) can request changes to the NCSC programs, in order of priority.
 
-3.a. Add recommendation for coordinated vulnerability disclosure.
+* \3.a. Add recommendation for coordinated vulnerability disclosure.
 
-3.b. Replace HackerOne with a UK national security provider and/or with peer-to-peer PGP/GPG keys.
+* \3.b. Replace HackerOne with a UK national security provider and/or with peer-to-peer PGP/GPG keys.
 
-3.c. Add recommendation for website footer "Security Policy".
-
+* \3.c. Add recommendation for website footer "Security Policy".
 
 ## Recommendation - Decision Outcome
 

--- a/united-kingom-national-cyber-security-centre/index.md
+++ b/united-kingom-national-cyber-security-centre/index.md
@@ -1,0 +1,50 @@
+# United Kingom (UK) National Cyber Security Centre (NCSC)
+
+**Status**: first sketch, work in progress, request for collaboration
+
+**Date**: 2025-03-27
+
+**Governance**: To Be Discovered; potentially a combo of this repo participants, UK NHS Wales DHCW CISO, UK NHS Wales UCB peers, etc.
+
+## Situation - Context and Problem Statement
+
+Broadly, we want cyber-security for our organisation, our various services, our open source, etc.
+
+Narrowly, we want the emergency department module authentication example to have good cyber-security practices from the get go.
+
+## Background - Decision Drivers
+
+NHS Wales has a variety of cyber-security practices, such as those being driven by the various university health boards and trusts.
+
+NHS Wales groups are in conversation with the United Kingdom (UK) National Cyber Security Centre (NCSC). For example, the NHS Wales DHCW CISO Deputy has regular meetings with UK NCSC, and Joel met (2025-03-27) with Alex at UK NCSC to discuss overall cyber-security.
+
+Alex describes that UK NCSC is advisory-only, not regulatory. Joel is currently unclear where the regulatory side of things is.
+
+## Assessment - Considered Options
+
+Alex at NCSC has suggested multiple options for us to consider:
+
+1. NCSC can provide a cyber-security assessment of our organisation, which we can then use to improve our cyber-security practices. Alex is going to send along more information about how this would work. There's extensive information on the NCSC website about this.
+
+1.a. NCSC can do this with each NHS Wales group separately.
+
+1.b. NCSC can do this with all the NHS Wales groups all together.
+
+2. In parallel, NHS Wales staff (e.g. Joel, Chris, etc.) can join the NCSC, in variuos ways.
+
+2.a. NCSC Slack channel, which involves 300+ security-related people who are advising the teams, requesting features, reporting issues, etc.
+
+2.b. NCSC planning-- unclear what this means-- need more info; it sounds somewhat like UK Government Design System team.
+
+3. NCSC has change management processes where DHCW (e.g. Joel, Chris, CISO, etc.) can request changes to the NCSC programs, in order of priority.
+
+3.a. Add recommendation for coordinated vulnerability disclosure.
+
+3.b. Replace HackerOne with a UK national security provider and/or with peer-to-peer PGP/GPG keys.
+
+3.c. Add recommendation for website footer "Security Policy".
+
+
+## Recommendation - Decision Outcome
+
+WIP. Currently, Joel is focusing on learning more about options 1.a., 2.a., 3.a.


### PR DESCRIPTION
Add United Kingdom National Cyber Security Center guidance.

## Motivation and Context

As per ADR, the specific driver is to add security to the emergency department authentication example.

## How to review

Sanity check please.