### PR TITLE
Create mkdocs.yml Automation for Publishing docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,33 @@
+# Publish the documentation using mkdocs to gh_pages 
+name: mkdocs
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  
+jobs:
+  mkdocs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure Git Credentials
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
+      - uses: actions/cache@v4
+        with:
+          key: mkdocs-material-${{ env.cache_id }}
+          path: .cache 
+          restore-keys: |
+            mkdocs-material-
+      - run: make install
+      - run: make sync
+      - run: make deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+site/

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,14 @@ run:
 	@echo "The documentation should now be available by browsing http://127.0.0.1:8000/"
 
 ##
+# deploy: build and deploy the latest docs to GitHub pages (gh_pages branch push)
+##
+.PHONY: deploy
+deploy:
+	uv run mkdocs gh-deploy
+	@echo "The documentation should now be available by browsing https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/"
+
+##
 # newline: display a newline character so we can print prettier messages.
 ##
 .PHONY: newline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: GIG Cymru NHS Wales - Architecture Decision Records
-site_url: https://sitename.example
+site_url: https://gig-cymru-nhs-wales.github.io/
 repo_url: https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/
 docs_dir: doc
 extra_css:
@@ -8,8 +8,6 @@ theme:
   name: material
   logo: assets/logo.png
   favicon: assets/favicon.ico
-  font:
-    text: Rubik
   palette:
     scheme: custom
 


### PR DESCRIPTION
## Description
Adds a GitHub Action to automate the publishing of our mkdocs 

## Related
See #9 and #12 for the introduction of mkdocs

## Motivation and Context
We want to auto-publish a public mkdocs site (via GitHub Pages) every time a commit is pushed to main

## How to review
Review the ``mkdocs.yml`` - is this correct, does it work?
