### PR TITLE
Add workflow for linting .md files under doc/ and fix mkdoc publishing

### DIFF
--- a/.github/config/custom.markdownlint.jsonc
+++ b/.github/config/custom.markdownlint.jsonc
@@ -1,0 +1,6 @@
+{
+    // See https://github.com/DavidAnson/markdownlint/blob/v0.32.1/schema/.markdownlint.jsonc
+
+    // MD013/line-length : Line length : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md013.md
+    "MD013": false
+}

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,20 @@
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: tj-actions/changed-files@v46
+      id: changed-files
+      with:
+        files: 'doc/*.md'
+        separator: ","
+    - uses: DavidAnson/markdownlint-cli2-action@v19
+      if: steps.changed-files.outputs.any_changed == 'true'
+      with:
+        config: '.github/config/custom.markdownlint.jsonc'
+        globs: ${{ steps.changed-files.outputs.all_changed_files }}
+        separator: ","

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ run:
 ##
 .PHONY: deploy
 deploy:
-	uv run mkdocs gh-deploy
+	uv run mkdocs gh-deploy --force
 	@echo "The documentation should now be available by browsing https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/"
 
 ##

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GIG Cymru NHS Wales - Architecture Decision Records
 
+[![mkdocs](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml/badge.svg)](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml)
+
 An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
 
 ## Introduction

--- a/doc/index.md
+++ b/doc/index.md
@@ -1,1 +1,27 @@
-# Welcome to GIG Cymru NHS Wales Architecture Decision Records
+# GIG Cymru / NHS Wales - Architecture Decision Records
+
+An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
+
+## Introduction
+
+* [Why write architecture decision records - By GitHub Engineering](https://github.blog/engineering/architecture-optimization/why-write-adrs/)
+
+* [A practical overview on Architecture Decision Records: How to start and why this could be your most valuable action as a software architect](https://ctaverna.github.io/adr/)
+
+## First Decisions
+
+Our first decisions are for [DHCW](https://https://dhcw.nhs.wales/) to utilise achitecture decision records, specify how we will name them and agree the format:
+
+* [Use Architecture Decision Records and Structure](design-authority\dhcw\use-architecture-decision-records-and-structure.md)
+* [Architecture Decision Records Naming Convention](design-authority\dhcw\architecture-decision-records-naming-conventions.md)
+* [Format Architecture Decision Records using plaintext Markdown](design-authority\dhcw\format-architecture-decision-records-with-markdown.md)
+* [Use Material for MkDocs for Publishing](design-authority\dhcw\use-material-for-mkdocs-for-publishing.md)
+
+## Creating a new record
+
+To create a new record:
+
+* Create a branch from ``main`` see [naming conventions](design-authority\dhcw\architecture-decision-records-naming-conventions.md)
+* Make a copy of [the template](design-authority\dhcw\architecture-decision-record-template.md).
+* Enter as much detail as you can in the record
+* Create a [Pull Request](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/pulls) on GitHub.com


### PR DESCRIPTION
## Description
Adds a Markdown linter check that will trigger for files changed for PRs

## Related
See #3 decision to use Markdown format

## Motivation and Context
Now we are publishing pages using mkdocs it is important that our Markdown documents are formatted correctly or they will cause formatting issues when published. This introduces a linter that will flag when markdown is not compliant.

## How to review
* Review the markdownlint.yml - this is based on https://github.com/marketplace/actions/markdownlint-cli2-action
* Note the custom config file - I have disabled MD013 line length must be 80 characters - is this agreed - it was failing on the first doc I tested.
