### PR TITLE
Fix markdownlint not checking doc/ subfolders

### DIFF
--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -10,7 +10,7 @@ jobs:
     - uses: tj-actions/changed-files@v46
       id: changed-files
       with:
-        files: 'doc/*.md'
+        files: 'doc/**/*.md'
         separator: ","
     - uses: DavidAnson/markdownlint-cli2-action@v19
       if: steps.changed-files.outputs.any_changed == 'true'

--- a/doc/design-authority/dhcw/architecture-decision-record-template.md
+++ b/doc/design-authority/dhcw/architecture-decision-record-template.md
@@ -1,4 +1,4 @@
-# {short title, representative of solved problem and found solution}
+# Architecture Decision Record Template
 
 **Status**: {proposed | rejected | accepted | deprecated | superseded by ABC...}  
 **Date**: {YYYY-MM-DD when the decision was last updated}  


### PR DESCRIPTION
## Description
The markdown linter was only check the doc/ folder root, not recursing through all sub directories. Fixed it.

## Related
#15 for original intro of the linter.

## Motivation and Context
Fixes a bug in the workflow, docs weren't being linted that should have been

## How to review
Check the linter is now linting files below the doc/ structure.