### PR TITLE
Add Simple Analytics, consent and fix homepage links

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -12,16 +12,16 @@ An Architecture Decision Record (ADR) is a document that captures an important a
 
 Our first decisions are for [DHCW](https://https://dhcw.nhs.wales/) to utilise achitecture decision records, specify how we will name them and agree the format:
 
-* [Use Architecture Decision Records and Structure](design-authority\dhcw\use-architecture-decision-records-and-structure.md)
-* [Architecture Decision Records Naming Convention](design-authority\dhcw\architecture-decision-records-naming-conventions.md)
-* [Format Architecture Decision Records using plaintext Markdown](design-authority\dhcw\format-architecture-decision-records-with-markdown.md)
-* [Use Material for MkDocs for Publishing](design-authority\dhcw\use-material-for-mkdocs-for-publishing.md)
+* [Use Architecture Decision Records and Structure](design-authority/dhcw/use-architecture-decision-records-and-structure.md)
+* [Architecture Decision Records Naming Convention](design-authority/dhcw/architecture-decision-records-naming-conventions.md)
+* [Format Architecture Decision Records using plaintext Markdown](design-authority/dhcw/format-architecture-decision-records-with-markdown.md)
+* [Use Material for MkDocs for Publishing](design-authority/dhcw/use-material-for-mkdocs-for-publishing.md)
 
 ## Creating a new record
 
 To create a new record:
 
-* Create a branch from ``main`` see [naming conventions](design-authority\dhcw\architecture-decision-records-naming-conventions.md)
-* Make a copy of [the template](design-authority\dhcw\architecture-decision-record-template.md).
+* Create a branch from ``main`` see [naming conventions](design-authority/dhcw/architecture-decision-records-naming-conventions.md)
+* Make a copy of [the template](design-authority/dhcw/architecture-decision-record-template.md).
 * Enter as much detail as you can in the record
 * Create a [Pull Request](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/pulls) on GitHub.com

--- a/doc/overrides/partials/integrations/analytics/simple.html
+++ b/doc/overrides/partials/integrations/analytics/simple.html
@@ -1,0 +1,18 @@
+<script>
+    /* Check if  consent was given for Simple Analytics */
+    var consent = __md_get("__consent")
+    if (consent && consent.analytics) {
+        /* properties not used currently */
+        var property = "{{ config.extra.analytics.property }}" 
+      
+        /* Wait for page to load and application to mount */
+        document.addEventListener("DOMContentLoaded", (event) => {
+            <!-- 100% privacy-first analytics -->
+            var simple_analytics=document.createElement("script");
+            simple_analytics.async=!0;
+            simple_analytics.src="https://scripts.simpleanalyticscdn.com/latest.js";
+            document.body.appendChild(simple_analytics);
+        });    
+      }
+
+  </script>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,11 +6,29 @@ extra_css:
   - stylesheets/extra.css
 theme:
   name: material
+  custom_dir: doc/overrides
   logo: assets/logo.png
   favicon: assets/favicon.ico
   palette:
     scheme: custom
-
+copyright: >
+  Copyright &copy; 2025 GIG Cymru - NHS Wales –
+  <a href="#__consent">Change cookie settings</a>
+extra:
+  consent:
+    title: Cookie consent
+    description: >- 
+      We use cookies to optimise site functionality and give you the best
+      possible experience, recognise your repeated visits and preferences, as
+      well as to measure the effectiveness of our site and whether
+      users find what they're searching for. With your consent, you're helping
+      us to make our site better.
+    cookies:
+      analytics:
+        name: Simple Analytics
+        checked: true
+  analytics:
+    provider: simple
 markdown_extensions:
   - admonition
   - pymdownx.details


### PR DESCRIPTION
## Description
Add support for Google Analytics and fix links on the homepage being broken. I setup a GA account and created a measurement ID for this.

## Motivation and Context
Adding GA will allow us to gather metrics as the site progresses on user behaviour and engagement.

## How to review
Check the changes to mkdocs.yml are correct as per https://squidfunk.github.io/mkdocs-material/setup/setting-up-site-analytics/
