### PR TITLE
Add published site URL to root README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![mkdocs](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml/badge.svg)](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml)
 
+This documents in this repository are published to [https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/](https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/).
+
 An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
 
 ## Introduction

--- a/cspell.json
+++ b/cspell.json
@@ -11,6 +11,7 @@
         "IGDC",
         "kickstarting",
         "mkdocs",
+        "Mkdoc",
         "NCSC",
         "shadcn",
         "UKNCSC"


### PR DESCRIPTION
## Description
Just add a link to our published GH Pages site to the repo's root README.md

## Related
#9 - Publishing the site with Material for MkDocs 

## Motivation and Context
Closes #27

## How to review
Check the markdown and link are correct 