### PR TITLE
Add DHCW TDA Architecture Principles

### DIFF
--- a/doc/.nav.yml
+++ b/doc/.nav.yml
@@ -2,6 +2,10 @@ append_unmatched: true
 flatten_single_child_sections: true
 nav:
   - Home: index.md
+  - Principles:
+    - DHCW Design Authority:
+      - design-authority/principles/index.md
+      - Principles: design-authority/principles/
   - Decisions:
     - DHCW Design Authority:
       - design-authority/dhcw/index.md

--- a/doc/design-authority/principles/README.md
+++ b/doc/design-authority/principles/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/architecture-principles/README.md
+++ b/doc/design-authority/principles/architecture-principles/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/architecture-principles/index.md
+++ b/doc/design-authority/principles/architecture-principles/index.md
@@ -1,0 +1,55 @@
+# Architecture Principles
+
+!!! warning
+
+    Proposed changes to these principles are under review by the DHCW TDA
+
+## Deliver sustainable services
+
+All digital services need to be delivered sustainably.
+
+## Put our Tools in Modern Browsers
+
+All digital services should be browser based and utilise open web standards.
+
+## Internet first
+
+All digital services should adopt internet standards and protocols including
+setting the default that services are available over the public internet.
+
+## Public Cloud first
+
+Digital services should move to the public cloud unless there is a clear reason
+not to do so.
+
+## Build a data layer with registers and APIs
+
+Digital services should only store data once (usually where collected) and make
+it available via open APIs whilst maintaining privacy and security.
+
+## Adopt appropriate cyber security standards
+
+Services must adopt the appropriate cyber security standards subject to risk
+appetite, including keeping all software, networks and systems up to date.
+
+## Use Platforms
+
+Digital services should build upon existing platforms to deliver their services.
+
+## Ask what the user need is
+
+Every service must be designed around user needs, whether the needs of the
+public, clinicians or other staff.
+
+## Interoperability with open data and technology standards
+
+Digital services should adopt open data and technology standards.
+
+## Reuse before buy / build
+
+Digital services should demonstrate that they have sought to reuse existing
+solutions before delivering new ones. Where is it not possible to reuse an
+existing solution, off the-shelf (commercial or open source) products should be
+considered. For open-source products there should be an appropriate level of
+contractual support provided. Only having ruled out the former two options
+should a new solution be built, either in-house or through third parties

--- a/doc/design-authority/principles/cloud-and-infrastructure/README.md
+++ b/doc/design-authority/principles/cloud-and-infrastructure/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/cloud-and-infrastructure/index.md
+++ b/doc/design-authority/principles/cloud-and-infrastructure/index.md
@@ -1,0 +1,67 @@
+# Cloud and Infrastructure Principles
+
+!!! success "Approved"
+
+    These principles have been approved by the DHCW TDA
+
+## Multi Cloud
+
+For SaaS solutions and specialist PaaS services, we will choose our provider
+based on analysis of capabilities in the marketplace. For IaaS and generic PaaS
+deployments we will identify a single provider of these services.
+
+## Make security easy to adopt
+
+Common security tooling and monitoring to be implemented for all clouds. We will
+build the underpinning cloud security infrastructure and monitoring systems, so
+that these are available for everyone to use. Technical solutions
+(guardrails/policies) will be implemented to reduce risk of user error when
+configuring cloud services.
+
+## Design for portability
+
+Design for portability and avoid vendor lock-in unless there is compelling case
+for doing so.
+
+## Design for self-service
+
+Leverage automation for infrastructure deployment, configuration management,
+and testing. Utilise Infrastructure as Code (IaC) practices and continuous
+integration/continuous deployment (CI/CD) pipelines. Self-service should be
+adopted where possible.
+
+## Keep the network simple, resilient and reliable
+
+The network systems should be kept as simple as possible with a focus on
+reliability and availability, even during periods of planned maintenance.
+
+## Optimise cloud benefits
+
+Maximise the benefits of using the cloud. Utilise the cloud services that
+deliver most value to the organisation. Select the most optimum service model
+(SaaS, FaaS, PaaS, IaaS, etc). Offload management overhead where possible.
+
+## Design for elasticity and cost optimisation
+
+Design for efficiency and cost minimisation – lever the elasticity of cloud
+services.
+
+## Design for reliability
+
+Design for high-availability, resilience, data protection and disaster recovery.
+Follow best practices and patterns available from the relevant cloud provider.
+
+## Design for performance
+
+Design applications and infrastructure to ensure that they meet user response
+time expectations and can grow and adapt to changes in demand.
+
+## Consider open-source first
+
+Optimise use of Open-Source vs Proprietary products. Choose the most
+economically advantageous solution.
+
+## Simplify and standardise
+
+Avoid technology sprawl. Balance the supportability implications of technology
+choices with the benefits of using unfamiliar technologies.

--- a/doc/design-authority/principles/data-and-analytics/README.md
+++ b/doc/design-authority/principles/data-and-analytics/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/data-and-analytics/index.md
+++ b/doc/design-authority/principles/data-and-analytics/index.md
@@ -1,0 +1,56 @@
+# Data & Analytics Principles
+
+!!! success "Approved"
+
+    These principles have been approved by the DHCW TDA
+
+## Data is captured once and reused
+
+Data is captured once and reused refers to the practice of collecting patient
+information (such as medical history, test results, and treatment plans) during
+an initial encounter and then using that data throughout the patient’s care
+journey. This approach aims to improve efficiency, reduce duplication, and
+enhance continuity of care.
+
+## Data is semantically interoperable
+
+Data is not only syntactically consistent (i.e. formatted correctly) but also
+semantically consistent. Different systems can understand and interpret the data
+in the same way because the data carries the same meaning across systems. For
+example, a diagnosis code or a medication name will be interpreted correctly
+regardless of the system accessing it.
+
+## Data for analytical use is not an after thought
+
+Secondary uses of data is integral to the design of any new applications.
+Publishing data to analytical stores must be included prior to deployment.
+
+## Data is secured
+
+Data is compliant with security, regulatory and privacy requirements.
+Appropriate measures have been implemented to protect it from unauthorised
+access, disclosure, alteration, or destruction. Data security involves
+safeguarding sensitive information and ensuring its confidentiality, integrity,
+and availability.
+
+This can be achieved through various technical, organisational, and procedural
+controls, such as encryption, access controls, authentication mechanisms, data
+backups, and security monitoring. Effective data security practices aim to
+mitigate risks associated with data breaches, cyber attacks, insider threats,
+and other security vulnerabilities, thereby safeguarding the privacy, trust,
+and reputation of individuals and organisations.
+
+## Data is findable, accessible and well described
+
+Data should be easy to find for both humans and computers. These data should be
+well described through comprehensive metadata and should include metrics
+relating to data quality and coverage. Data should be easily discoverable,
+available for authorised users, and accompanied by detailed documentation that
+enhances its understanding and usability.
+
+## Data is high quality
+
+Data quality is monitored and reported. High-quality data serves as a reliable
+foundation for analysis, decision-making, and insights generation. It instils
+confidence in the results derived from data-driven processes and provides the
+opportunity to derive maximum value from data assets.

--- a/doc/design-authority/principles/digital-workplace/README.md
+++ b/doc/design-authority/principles/digital-workplace/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/digital-workplace/index.md
+++ b/doc/design-authority/principles/digital-workplace/index.md
@@ -1,0 +1,69 @@
+# Digital Workplace Principles
+
+!!! success "Approved"
+
+    These principles have been approved by the DHCW TDA
+
+## Employee experience is always a key priority
+
+When designing, implementing, configuring or procuring products for the Digital
+Workplace, the employee (end-user) experience is always a key priority. Systems
+should be designed to meet user needs. Staff need to have the right tools for
+the right job.
+
+## Support must be proactive in nature and driven by data
+
+Proactive support reduces avoidable downtime and service disruption for our
+employees. Monitoring the user experience and underpinning infrastructure
+enables a shift to more proactive incident and problem management.
+
+## Flexibility to work effectively from multiple locations and on multiple devices
+
+Employees will have the same rich digital workplace experience from all approved
+locations, whether from a DHCW office, other NHS premises or a location with
+only internet access, and from any approved device.
+
+Solutions must be designed to support an optimal hybrid-working experience and
+employees who have a blended work pattern (office, home/remote).
+
+## The Digital Workplace exploits AI and Automation
+
+AI and automation supports and augments the work of the employee, freeing up
+time for higher-value work and improved employee wellbeing.
+
+## Adopt modern technologies and best practices
+
+Modern technologies and practices provide a richer digital experience for
+employees, allowing them to benefit from the latest features and services to
+support them in their work.
+
+## Security as an enabler
+
+Robust security measures must be implemented to both protect data and resources,
+but also facilitate enhanced production, collaboration and innovation.
+
+## Digital First
+
+Systems and processes that support the Digital Workplace should be digital by
+design, reducing and eventually removing the need for manual alternatives.
+
+## Reduce the Carbon Footprint
+
+Reducing the carbon footprint of the Digital Workplace is essential to support
+decarbonisation goals.
+
+## Supporting the accessibility needs of workforce
+
+Systems that underpin the Digital Workplace must enable all staff to work to the
+best of their abilities and support any staff with particular needs.
+
+## Supporting the use of the Welsh Language
+
+We will ensure that Welsh language interfaces and supporting technology is made
+easily available to our users. Welsh language requirements will be included as
+part of the procurement for relevant services.
+
+## Internet First
+
+When designing, implementing, configuring or procuring products for the Digital
+Workplace.

--- a/doc/design-authority/principles/index.md
+++ b/doc/design-authority/principles/index.md
@@ -1,0 +1,17 @@
+# Introduction
+
+The following principles have been approved by the DHCW Technical Design
+Authority (TDA):
+
+* [Architecture Principles](architecture-principles/index.md)
+* [Open Architecture & Integration](open-architecture/index.md)
+* [Digital Workplace](digital-workplace/index.md)
+* [Data & Analytics](data-and-analytics/index.md)
+* [Cloud & Infrastructure](cloud-and-infrastructure/index.md)
+* [Security & Identity](security-and-identity/index.md)
+
+The following principles are under development:
+
+* [User-Centred Design Principles](user-centred-design/index.md)
+* Digital Products & Software Engineering
+* Clinical Principles

--- a/doc/design-authority/principles/open-architecture/README.md
+++ b/doc/design-authority/principles/open-architecture/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/open-architecture/index.md
+++ b/doc/design-authority/principles/open-architecture/index.md
@@ -1,0 +1,41 @@
+# Open Architecture & Integration Principles
+
+!!! success "Approved"
+
+    These principles have been approved by the DHCW TDA
+
+## API First
+
+APIs will be the primary interface through which our platforms and products
+interact and exchange data.
+
+## Open Architecture
+
+Our architecture will be open, enabled by discoverable, well documented,
+standards based and reusable APIs and governed by appropriate and proportionate
+onboarding processes.
+
+## Open Standards
+
+Interactions and data exchange between platforms and products will be based on
+open standards by default.
+
+## Secure by Design
+
+Our APIs, platforms and products will be designed and built to be secure from
+the ground up.
+
+## Shift assurance left
+
+Assurance, governance and quality will be built into our platforms and products
+from the ground up.
+
+## User centric & focused on value
+
+Platforms and products will be designed with our users in mind and architecture
+decisions will consider what will generate the best return of value in the
+long run.
+
+## Flexible, Modular & Scalable
+
+We will design our platforms and products to be flexible, modular and scalable.

--- a/doc/design-authority/principles/security-and-identity/README.md
+++ b/doc/design-authority/principles/security-and-identity/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/security-and-identity/index.md
+++ b/doc/design-authority/principles/security-and-identity/index.md
@@ -1,0 +1,65 @@
+# Identity & Security Principles
+
+## Security as an enabler
+
+Security should be viewed not as a barrier but a fundamental element that
+supports and enhances business objectives, innovation, and operation efficiency.
+Robust security measures will enable agility and trust.
+
+## Minimum effective toolset
+
+Use the smallest number of tools and solutions necessary to achieve security
+objective effectively.
+
+## Secure supply chain
+
+Ensure the supply chain is secured by ensuring the security, integrity and
+reliability of all parties responsible for delivery of services or products.
+This will involve an assessment of  security controls and standards of a
+supplier, and their incident response plans and capability.
+
+## Assume when not if
+
+Instead of assuming a security breach might happen, DHCW must assume it will
+happen and plan accordingly. This will mean elevating response and recovery
+capabilities to the same status of detection and prevention.
+
+## Design for Isolation where possible
+
+Systems, applications and processes should be compartmentalised where possible.
+Systems, applications and processes should be designed to isolate components and
+restrict their interaction unless explicitly required.
+
+## Zero Trust
+
+No device, user or system should be automatically trusted whether inside or
+outside the network perimeter, and must be given the minimum access necessary
+to complete their tasks (least privilege). All interactions must be monitored
+and audited.
+
+## Defence in depth
+
+Multiple layers of security controls and measures must be implemented to protect
+systems, infrastructure and data.
+
+## Secure by Design
+
+Security must be incorporated into the design and development process of
+systems, infrastructure and applications from the start of the project, rather
+than considering security late in the design lifecycle.
+
+## Single source of truth
+
+All users, applications and systems rely on a single, consistent, and
+authoritative source for authentication and user data.
+
+## Verify then Trust Emerging Technologies
+
+New technology such as GenAI must be comprehensively evaluated and validated
+before use by DHCW, particularly for critical systems.
+
+## Simple as Possible
+
+Minimise the complexity of the design, implementation and management of systems,
+applications and processes where possible. Use validated or previously used
+successful designs where possible.

--- a/doc/design-authority/principles/user-centred-design/README.md
+++ b/doc/design-authority/principles/user-centred-design/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/principles/user-centred-design/index.md
+++ b/doc/design-authority/principles/user-centred-design/index.md
@@ -1,0 +1,71 @@
+# User-Centred Design (UCD) Principles
+
+!!! Note
+
+    These principles are not yet approved by the DHCW TDA
+
+## Start with user needs
+
+Test your assumptions.
+
+Public services are for everyone and must be driven by user needs.
+
+User research prevents wasted resources and reveals real problems,
+enabling evidence-based, cost-effective decisions.
+
+## Design with  data
+
+Use data to make decision.
+
+Continuously monitor service performance and use data and user feedback to
+prioritise improvements and identify problems that need to be fixed
+
+## Do the hard work to make it simple and inclusive
+
+Make the service easy to use and make sure everyone can use it.
+
+Design inclusively, ensuring easy access for all, including those often
+excluded.
+
+Healthcare can be complex. Do the hard work to make it simpler
+
+## Design for outcome and context
+
+Consider what good will look like, how it fits with the entire services, and how
+you will measure outcomes.
+
+Understand users and their needs in the context of health and care.
+
+## Iterate. Learn, Improve
+
+Use an incremental, fast-paced approach to get working products into users’
+hands as early as possible, as often as possible.
+
+Rapidly iterate and focus on the improvements that have the most value, based on
+user feedback.
+
+## Make things open and consistent
+
+Use and contribute to open standards, common components and patterns and share
+what you’re doing whenever you can.
+
+## Design services in Welsh and English
+
+Design and build services that promote and ease the use of Welsh and treat those
+who speak it equally with those who speak English.
+
+## Design for trust
+
+Services must be secure and safe to maintain users’ trust.
+
+Digital information, tools and services have the potential to cause patient
+harm.
+
+Respect and protect users' confidentiality and privacy.
+
+## Minimise environmental impact
+
+The climate crisis is a health crisis.
+
+Follow sustainability best practice to reduce the environmental impact of your
+service across its lifespan.

--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,11 @@
 
 This site provides NHS Wales architecture related information.
 
-## Introduction to Architecture Decision Records
+## Principles
+
+See [DHCW Architecture Principles](design-authority/principles/index.md)
+
+## Decisions
 
 An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
 


### PR DESCRIPTION
## Description
We want to work in the open and transparently, This PR adds the principles both approved and under discussion by the DHCW Technical Design Authority to the repository and publishes them under a top-level navigation of 'Principles'.

## Motivation and Context
Close #31 

## How to review
* Run the site local ``make run`` and verify the principles are published correctly (see below).
* Review the markdown and folder structure, are thoughts?

![image](https://github.com/user-attachments/assets/d2316d9e-2b81-4967-9266-acc2b29c3aad)
