### PR TITLE
Start capturing EA Metamodel decisions

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -5,6 +5,7 @@
     "dictionaryDefinitions": [],
     "dictionaries": [],
     "words": [
+        "Ardoq",
         "CISO",
         "daemonless",
         "DHCW",
@@ -13,6 +14,7 @@
         "IGDC",
         "kickstarting",
         "Knative",
+        "metamodel",
         "mkdocs",
         "Mkdoc",
         "NCSC",

--- a/doc/.nav.yml
+++ b/doc/.nav.yml
@@ -7,17 +7,13 @@ nav:
       - design-authority/principles/index.md
       - Principles: design-authority/principles/
   - Decisions:
+    - Decision Template: design-authority/dhcw/architecture-decision-record-template.md
     - DHCW Design Authority:
       - design-authority/dhcw/index.md
       - Decisions: design-authority/dhcw/
-<<<<<<< HEAD
-    - Decision Template: design-authority/dhcw/architecture-decision-record-template.md
-=======
     - Enterprise Architecture Metamodel:
       - design-authority/ea-metamodel/index.md
       - Metamodel Decisions: design-authority/ea-metamodel/ 
-    - Template: design-authority/dhcw/architecture-decision-record-template.md
->>>>>>> e3d9f93 (Start capturing EA Metamodel decisions)
     - Meta Decisions:
       - meta-decisions/*
     - Development:

--- a/doc/.nav.yml
+++ b/doc/.nav.yml
@@ -10,7 +10,14 @@ nav:
     - DHCW Design Authority:
       - design-authority/dhcw/index.md
       - Decisions: design-authority/dhcw/
+<<<<<<< HEAD
     - Decision Template: design-authority/dhcw/architecture-decision-record-template.md
+=======
+    - Enterprise Architecture Metamodel:
+      - design-authority/ea-metamodel/index.md
+      - Metamodel Decisions: design-authority/ea-metamodel/ 
+    - Template: design-authority/dhcw/architecture-decision-record-template.md
+>>>>>>> e3d9f93 (Start capturing EA Metamodel decisions)
     - Meta Decisions:
       - meta-decisions/*
     - Development:

--- a/doc/design-authority/ea-metamodel/README.md
+++ b/doc/design-authority/ea-metamodel/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/ea-metamodel/ea-metamodel-compliance.groovy
+++ b/doc/design-authority/ea-metamodel/ea-metamodel-compliance.groovy
@@ -1,0 +1,54 @@
+def validReferences = [
+  ['Business Capability', 'Is Realized By', 'Application'],
+  ['Business Capability', 'ardoq_parent', 'Business Capability'],
+  ['Technical Capability', 'Is Realized By', 'Application'],
+  ['Technical Capability', 'ardoq_parent', 'Technical Capability'],
+  //
+  ['Person', 'Is Expert In', 'Application'],
+  ['Person', 'Is Expert In', 'Business Capability'],
+  ['Person', 'Owns', 'Application'],
+  //
+  ['Organizational Unit', 'Consumes', 'Application'],
+  ['Organizational Unit', 'Consumes', 'Application Module'],
+  ['Organizational Unit', 'Supplies', 'Application'],
+  ['Organizational Unit', 'Supports', 'Application'],
+  ['Organizational Unit', 'Owns', 'Application'],
+  ['Organizational Unit', 'ardoq_parent', 'Organization'],
+  ['Organizational Unit', 'ardoq_parent', 'Organizational Unit'],
+  ['Organizational Unit', 'Partners With', 'Organizational Unit'],
+  //
+  ['Application Module', 'ardoq_parent', 'Application'],
+  ['Application', 'ardoq_parent', 'Application'],
+  ['Application', 'ardoq_parent', 'Application Group'],
+  ['Application', 'Has Successor', 'Application'],
+  ['Application', 'Connects To', 'Application'],
+  ['Application', 'Depends On', 'Application'],
+  ['Interface', 'ardoq_parent', 'Application'],
+  ['Interface', 'Connects To', 'Application']
+]
+
+def isLegalReference = {
+  project('sourceType', 'type', 'targetType').
+    by(outV().label()).
+    by(label()).
+    by(inV().label()).
+  filter{
+    validReferences.any{ validReference ->
+      validReference[0] == it.get()['sourceType'] &&
+      validReference[1] == it.get()['type'] &&
+      validReference[2] == it.get()['targetType']
+    }
+  }
+}
+
+g.V().
+  hasLabel('Application', 'Business Capability', 'Person', 'Organizational Unit').
+  bothE().
+  dedup().
+  not(isLegalReference()).
+  project('source', 'source type', 'reference', 'target', 'targetType type').
+    by(outV().values('name')).
+    by(outV().label()).
+    by(label()).
+    by(inV().values('name')).
+    by(inV().label())

--- a/doc/design-authority/ea-metamodel/index.md
+++ b/doc/design-authority/ea-metamodel/index.md
@@ -49,7 +49,7 @@ graph TD
 !!! tip
 
     See [Mermaid Docs](https://mermaid.js.org/syntax/flowchart.html) for more
-    information on creating/editing these diagrams.
+    information on creating/editing these diagrams and the [Mermaid Live Editor](https://mermaid.live/edit).
 
 ## Metamodel Compliance Query
 

--- a/doc/design-authority/ea-metamodel/index.md
+++ b/doc/design-authority/ea-metamodel/index.md
@@ -1,0 +1,67 @@
+# Introduction
+
+Our Enterprise Architecture Metamodel provides a structured overview of the
+core component types and their relationships within our model.
+
+We are utilising a single shared instance of [Ardoq](https://www.ardoq.com/) to
+model the health and care architecture across NHS Wales.
+
+Our metamodel is derived from the [Ardoq Use Case Solutions](https://help.ardoq.com/en/collections/6889-ardoq-use-case-solutions)
+and customised the fit the context of NHS Wales. Any deviations from the Ardoq
+recommended metamodel are capture as metamodel decisions.
+
+## Decisions
+
+!!! warning
+
+    If a new decision/change is made to the metamodel ensure the metamodel
+    diagram here is updated alongside the Gremlin query and associated report
+    in Ardoq
+
+The following decisions have been made regarding the metamodel:
+
+* [Multiple Application Instances](multiple-application-instances/index.md)
+
+## Metamodel Diagram
+
+This is a high-level diagram of the metamodel to aid comprehension, it is a
+non-exhaustive view and therefore  doesn't capture every aspect of the model.
+
+``` mermaid
+graph TD
+  accTitle: Enterprise Architecture Metamodel.
+  accDescr: A diagram showing a high level relationships between components in the enterprise architecture metamodel.
+  Business_Capability -->|Is Realized By| Application
+  Technical_Capability -->|Is Realized By| Application
+  Person -->|Belongs To| Organization
+  Person -->|Assigned To| Roles
+  Person -->|Owns, Is Expert In| Application
+  Organisation -->|Own, Supports, Supplies, Consumes| Application
+  External_Organisation -->|Supplies| Application
+  Application -->|Is Supported By| Database
+  Application -->|Accesses / Connects To| Logical_Information
+  Application -->|Connects To / Is Supported By / Depends On| Technology_Service
+  Infrastructure -->|Is Supported By| Database
+  Database -->|Is Located At| Locations
+  Technology_Services -->|Is Supported By| Infrastructure
+```
+
+!!! tip
+
+    See [Mermaid Docs](https://mermaid.js.org/syntax/flowchart.html) for more
+    information on creating/editing these diagrams.
+
+## Metamodel Compliance Query
+
+A Gremlin query is maintained within Ardoq to produce a "Metamodel Compliance"
+report. It will identify any relationships between components that do not match
+the agreed metamodel (i.e. non-compliant 'source -> reference -> target'
+relationships).
+
+The source for this query is maintained within the ``ea-metamodel-compliance.groovy``
+file of this repository, allowing for version control. The contents of the
+latest version of this query can be seen below:
+
+``` groovy title="ea-metamodel-compliance.groovy"
+--8<-- "doc/design-authority/ea-metamodel/ea-metamodel-compliance.groovy"
+```

--- a/doc/design-authority/ea-metamodel/multiple-application-instances/README.md
+++ b/doc/design-authority/ea-metamodel/multiple-application-instances/README.md
@@ -1,0 +1,1 @@
+index.md

--- a/doc/design-authority/ea-metamodel/multiple-application-instances/index.md
+++ b/doc/design-authority/ea-metamodel/multiple-application-instances/index.md
@@ -1,0 +1,33 @@
+# Multiple Application Instances
+
+!!! Success
+
+    **Decision Made:** 09/05/2025
+
+## Decision Required
+
+How to represent multiple instances of an Application.
+
+## Description
+
+Where a Application has a separate instances for different consumers (e.g. each Health Board has its own instance of an Application ~ such as WelshPAS) we need a way to represent this.
+
+## Decision
+
+There will be a 'generic' representation of the Application in the metamodel and each 'instance' of the Application will be represented as children with a descriptive identified added to the name e.g.
+
+## Rationale
+
+Whilst this adds complexity to the model and will lead to duplication it better represents the reality of the enterprise and the inherent complexity. In addition, it allows relationships that are specific to a particular instance to be modelled.
+
+## Model Diagram
+
+``` mermaid
+graph TD
+  accTitle: Example WelshPAS Instances Model
+  accDescr: Shows an example of the parent/child relationship for WelshPAS where each Health Board has its own instance of the application.
+  WelshPAS --> W1["WelshPAS [ABUHB]"]
+  WelshPAS --> W2["WelshPAS [BCUHB]"]
+  WelshPAS --> W3["WelshPAS [CTM]"]
+  WelshPAS --> W4["WelshPAS [...]"]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: GIG Cymru NHS Wales - Architecture
 site_url: https://gig-cymru-nhs-wales.github.io/
 repo_url: https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/
 docs_dir: doc
+edit_uri: edit/main/doc/
 extra_css:
   - stylesheets/extra.css
 theme:
@@ -14,6 +15,9 @@ theme:
   features:
     - navigation.tabs
     - navigation.footer
+    - content.action.edit
+    - content.action.view
+    - content.code.copy
 copyright: >
   Copyright &copy; 2025 GIG Cymru - NHS Wales –
   <a href="#__consent">Change cookie settings</a>
@@ -40,8 +44,19 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
+<<<<<<< HEAD
   - pymdownx.tabbed:
       alternate_style: true
+=======
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      check_paths: true
+  - pymdownx.superfences
+>>>>>>> e3d9f93 (Start capturing EA Metamodel decisions)
 plugins:
   - search
   - table-reader

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,10 +44,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-<<<<<<< HEAD
   - pymdownx.tabbed:
       alternate_style: true
-=======
   - pymdownx.highlight:
       anchor_linenums: true
       line_spans: __span
@@ -55,8 +53,6 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets:
       check_paths: true
-  - pymdownx.superfences
->>>>>>> e3d9f93 (Start capturing EA Metamodel decisions)
 plugins:
   - search
   - table-reader


### PR DESCRIPTION
## Description
Introduce the Enterprise Architecture Metamodel with an overview of core components and their relationships; leveraging a Mermaid diagram.

Adds a copy of the Ardoq Gremlin query used for metamodel compliance so we can start version tracking it as changes to the metamodel are made.

Provided an example decision around multiple application instances and suggests a template for capturing metamodel decisions.

Also updates navigation and changes MkDocs configuration to support embedded code with syntax highlighting.

## Related
#62 introduced the use of Mermaid for diagrams.

## Motivation and Context
Resolves #53 - Capture EA Metamodel Decisons

## How to review
* Ideally run Material for MkDocs locally to see the changes (you can use Codespaces)
* Review the doc/design-authority/ea-metamodel/index.md 
* Review the example metamodel decisions (doc\design-authority\ea-metamodel\multiple-application-instances\index.md)
* Thoughts on the placement of these in the navigation?
* Do you agree with the format/headings?
* Are the mermaid diagrams appropriate/useful?
* Thoughts on capturing the Gremlin query in its own file for version control?

## Screenshots

**Published version of the Introduction**

![image](https://github.com/user-attachments/assets/abc6235d-e61a-4df4-8f62-68cde80ed578)

**Example Decision for multiple Application instances**

![image](https://github.com/user-attachments/assets/201c2108-3b06-4029-9cbe-258e4064e60d)

