### PR TITLE
Add contributing file

### DIFF
--- a/CONTIRBUTING.md
+++ b/CONTIRBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+We welcome people contributing. We welcome feedback, suggestions, ideas, and help.
+
+To contact a particular repository's team, a good way is to create a GitHub issue.
+
+To contribute code to a particular repository, a good way is to create a GitHub pull request.
+
+To email a particular person, contact information will typically be provided in each repository's top level README file.
+
+If you need more help, such as a direct contact person, then please contact Joel Henderson at <joel.henderson@wales.nhs.uk>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing
+
+We welcome people contributing. We welcome feedback, suggestions, ideas, and help.
+
+To contact a particular repository's team, a good way is to create a GitHub issue.
+
+To contribute code to a particular repository, a good way is to create a GitHub pull request.
+
+To email a particular person, contact information will typically be provided in each repository's top level README file.
+
+If you need more help, such as a direct contact person, then please contact Joel Henderson at <joel.henderson@wales.nhs.uk>.


### PR DESCRIPTION
Geoff makes the good point that our org repos need to explain contributing. This file is a placeholder until TGA/TDAG/whomever writes something more-specific for the ADR repo.