### PR TITLE
Update repository links and README for consistency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ run:
 .PHONY: deploy
 deploy:
 	uv run mkdocs gh-deploy --force
-	@echo "The documentation should now be available by browsing https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/"
+	@echo "The documentation should now be available by browsing https://gig-cymru-nhs-wales.github.io/architecture-decision-records/"
 
 ##
 # newline: display a newline character so we can print prettier messages.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # GIG Cymru NHS Wales - Architecture Decision Records
 
-[![mkdocs](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml/badge.svg)](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/actions/workflows/publish.yml)
+[![mkdocs](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/actions/workflows/publish.yml/badge.svg)](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/actions/workflows/publish.yml)
 
-The documents in this repository are published to [https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/](https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/).
+The documents in this repository are published to [https://gig-cymru-nhs-wales.github.io/architecture-decision-records/](https://gig-cymru-nhs-wales.github.io/architecture-decision-records/).
 
 An Architecture Decision Record (ADR) is a document that captures an important architecture decision made along with its context and consequences.
 
@@ -19,7 +19,7 @@ There are several ways to set up your development environment:
 
 The fastest way to start contributing:
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/GIG-Cymru-NHS-Wales/Architecture-Decision-Records?quickstart=1)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/GIG-Cymru-NHS-Wales/architecture-decision-records?quickstart=1)
 
 This provides:
 
@@ -56,8 +56,8 @@ is faster on subsequent launches as the environment is then cached.
 Clone the repository:
 
 ```bash
-    git clone https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records.git
-    cd Architecture-Decision-Records
+    git clone https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records.git
+    cd architecture-decision-records
 ```
 
 Install uv (if not already installed):

--- a/doc/design-authority/dhcw/architecture-decision-record-process/index.md
+++ b/doc/design-authority/dhcw/architecture-decision-record-process/index.md
@@ -60,7 +60,7 @@ required for:
 
 ## Initiation and Commissioning
 
-Prior to the creation of an ADR it is recommended that an [Issue](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/issues)
+Prior to the creation of an ADR it is recommended that an [Issue](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/issues)
 is raised in this GitHub repository outlining the need for a new ADR (or
 update to an existing one). This enables very early discussion around the
 potential ADR with minimal outlay and effort.
@@ -71,14 +71,14 @@ encouraged to use the standard Git/GitHub workflow and raise a Pull Request
 
 ??? Tip "Example Git Workflow"
 
-    * Clone this repository: `git clone git@github.com:GIG-Cymru-NHS-Wales/Architecture-Decision-Records.git`
+    * Clone this repository: `git clone git@github.com:GIG-Cymru-NHS-Wales/architecture-decision-records.git`
     * Create a branch from `main` to work on (see [Naming Conventions](../architecture-decision-records-naming-conventions/index.md)):
       `git checkout main`, `git checkout -b adr-for-x`
     * Make the required changes (add/update files) in your editor of choice.
       (note [the template](../architecture-decision-record-template.md))
     * Commit the changes: `git add changed-file.md`, `git commit -m "Added new ADR for x"`
     * Push the changes to GitHub `git push -u origin HEAD`
-    * Raise a [Pull Request](https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/pulls) on GitHub.com
+    * Raise a [Pull Request](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/pulls) on GitHub.com
 
 Notwithstanding the above guidance, the Technical Design Authority (TDA),
 Technical Design Assurance Group (TDAG), or other relevant governance bodies

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: GIG Cymru NHS Wales - Architecture
-site_url: https://gig-cymru-nhs-wales.github.io/Architecture-Decision-Records/
-repo_url: https://github.com/GIG-Cymru-NHS-Wales/Architecture-Decision-Records/
+site_url: https://gig-cymru-nhs-wales.github.io/architecture-decision-records/
+repo_url: https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/
 docs_dir: doc
 edit_uri: edit/main/doc/
 extra_css:


### PR DESCRIPTION
## Description
Update all references in the README and configuration files to use the correct lowercase repository name for clarity and consistency after the repository has been renamed from Title-Case to lower-case.

## Related
Resolves #91

## Motivation and Context
See #91

## How to review
* Verify the changes only affect URL/config related to the repository name switching to lowercae