### PR TITLE
Publish TDA meeting outcomes 2025-07-25

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -12,21 +12,18 @@
         "Descr",
         "DHCW",
         "Fargate",
+        "FHIR",
         "Fiori",
-        "IGDC",
         "isolatability",
         "isolatable",
-        "kickstarting",
         "Knative",
         "metamodel",
         "Mkdoc",
         "mkdocs",
         "NCSC",
         "Pulumi",
-        "shadcn",
         "TDA",
-        "TDAG",
-        "UKNCSC"
+        "TDAG"
     ],
     "ignoreWords": [],
     "import": []

--- a/doc/design-authority/dhcw/meetings/25-06-2025/index.md
+++ b/doc/design-authority/dhcw/meetings/25-06-2025/index.md
@@ -1,11 +1,37 @@
 # DHCW TDA 25/07/2025
 
+## Previous Actions
+
+See [TDA 13/06/2025](../13-06-2025/index.md)
+
+| Ref      | Owner | Description | Status |
+| -------- | ----- | ----------- | ------ |
+| TDA-A001 | IE/CC | Identify key individuals to be involved in the top level architecture principles | ✅ Done |
+| TDA–A002 | RR/CC | Share the outcomes and actions from TDA on the NHS Wales Architecture site going | ✅ Done |
+| TDA–A003 | RR/CC | Create a plan for how to communicate and advertise the ADR process within DHCW | Ongoing |
+
 ## Items
 
 | Reference | Item | Outcome |
 | --------- | ---- | ------- |
+| TDA-006   | Update [Terms of Reference​](../../terms-of-reference/index.md) | Approved & Action TDA-A004 |
+| TDA-007   | Approval of [Digital Products & Software Engineering ​Principles](../../../../principles/digital-products-and-software-engineering/index.md) | Approved |
+| TDA-008   | Approval of [UCD Principles​](../../../../principles/user-centred-design/index.md) | Approved |
+| TDA-009   | Approval of revisions to [Level 1 Architecture Principles​](../../../../principles/architecture-principles/index.md) | Approved & Actions TDA-A005, TDA-A006, TDA-A007, TDA-A008 |
+| TDA-010   | [Cloud Selection ADR​](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/issues/30) | Approved & Action TDA-A009 |
+| TDA-011   | Update on National Target Architecture ​| N/A |
+| TDA-012   | API Delivery Framework​ | Action TDA-A010 |
+| TDA-013   | Review of [Clinical Principles​](../../../../principles/clinical/index.md) | Action TDA-A011 |
 
 ## Actions
 
-| Ref      | Owner | Description |
-| -------- | ----- | ----------- |
+| Ref      | Owner    | Description |
+| -------- | -------- | ----------- |
+| TDA-A004 | AJ/CC    | Update [Terms of Reference​](../../terms-of-reference/index.md) to reflect updated membership |
+| TDA-A005 | CC/GW/RR | Incorporate system design and procurement implications for single source of truth principle |
+| TDA-A006 | JH/RM    | Review policy for supported browser versions and implications, considering GOV.UK work in this area |
+| TDA-A007 | CC       | Review order of top level architecture principles, moving start with user needs to the top etc. |
+| TDA-A008 | CC/GW    | Propose an ADR for the use of FHIR before considering other healthcare standards for interoperability |
+| TDA-A009 | CL       | Form a Temporary Decision Group (TDG) to develop an Architecture Decision Record (ADR) and framework for the selection of Cloud provider for products and services |
+| TDA-A010 | RR       | Develop ways of working around API Delivery model for review |
+| TDA-A011 | All      | Review [Clinical Principles​](../../../../principles/clinical/index.md) for approval an next TDA |

--- a/doc/design-authority/dhcw/terms-of-reference/index.md
+++ b/doc/design-authority/dhcw/terms-of-reference/index.md
@@ -34,10 +34,32 @@ The following or delegates are required to be quorate:
 
 * Executive Director of Strategy
 * Executive Director of Operations
-* Chief Digital Architect
+* Chief Product and Technology Officer
 * Chief Data Officer
 * Cyber Security
 
 In addition, specific domain leads (or delegates) are required to be quorate if
 a paper/submission is relevant to their domain. This will be determined by the
 chair.
+
+## Scope
+
+**In Scope​:**
+
+All architecture domains:
+
+* Digital Workplace​
+* Digital Products & Software Engineering​
+* Open Architecture & Integration​
+* Data & Analytics​
+* Security & Identity​
+* Cloud & Infrastructure
+* User-Centred Design
+* Clinical
+
+**Out of Scope:**
+
+* Business change/readiness​
+* Project or programme governance​
+* Existing projects or solutions (other than major changes)​
+* Compliance

--- a/includes/abbreviations.md
+++ b/includes/abbreviations.md
@@ -1,0 +1,7 @@
+<!-- markdownlint-disable-next-line MD041 -->
+*[CCIO]: Chief Clinical Information Officer
+*[CISO]: Chief Information Security Officer
+*[FHIR]: Fast Healthcare Interoperability Resources
+*[NCSC]: National Cyber Security Centre
+*[TDAG]: Technical Design Assurance Group
+*[TDG]: Temporary Decision Group

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,7 +37,9 @@ extra:
   analytics:
     provider: simple
 markdown_extensions:
+  - abbr
   - admonition
+  - attr_list
   - pymdownx.details
   - pymdownx.superfences:
       custom_fences:
@@ -53,7 +55,11 @@ markdown_extensions:
   - pymdownx.inlinehilite
   - pymdownx.snippets:
       check_paths: true
+      auto_append:
+        - includes/abbreviations.md
 plugins:
   - search
   - table-reader
   - awesome-nav
+watch:
+  - includes


### PR DESCRIPTION
## Description
This PR adds agenda items and actions from the meeting of the DHCW Technical Design Authority (TDA) on 25th July 2025, including the update Terms of Reference for TDA.

Also adds support for Abbreviations to our Material for Mkdocs site (e.g. for things like FHIR) - you can now hover over the abbreviation to see the full name.


## Related
#94 

## How to review
* Check content of the TDA page for 25th July.
* Check mkdocs.yml config changes
* Check the new `includes/abbreviations.md` - noting the markdown lint disabled for requiring a H1 heading.
* Verify abbreviations work correctly on the running site (specifically for FHIR as an example)
