### PR TITLE
Fix linting and spelling config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .git/
 .github/
 .venv/
-.vscode
 site/

--- a/.vscode/mkdocs-custom-schema.json
+++ b/.vscode/mkdocs-custom-schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Custom MkDocs Schema for NHS Wales Architecture",
+  "description": "Extends the official Material for MkDocs schema to allow for custom plugins.",
+  "allOf": [
+    {
+      "$ref": "https://squidfunk.github.io/mkdocs-material/schema.json"
+    }
+  ],
+  "properties": {
+    "plugins": {
+      "type": ["array", "object"],
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "https://squidfunk.github.io/mkdocs-material/schema.json#/properties/plugins/items"
+          },
+          {
+            "const": "awesome-nav",
+            "description": "Enables the awesome-nav plugin for folder-based navigation."
+          }
+        ]
+      }
+    }
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "search.followSymlinks": false,
+  "yaml.schemas": {
+    "https://squidfunk.github.io/mkdocs-material/schema.json": [
+      "mkdocs.yml"
+    ],
+    "./.vscode/mkdocs-custom-schema.json": "mkdocs.yml",
+    "file:///c%3A/Users/Ch312943/Projects/architecture-decision-records/.vscode/mkdocs-custom-schema.json": "file:///c%3A/Users/Ch312943/Projects/architecture-decision-records/mkdocs.yml"
+  }
+}

--- a/cspell.json
+++ b/cspell.json
@@ -1,7 +1,7 @@
 {
     "version": "0.2",
     "language": "en,en-GB",
-    "ignorePaths": [],
+    "ignorePaths": ["mkdocs.yml"],
     "dictionaryDefinitions": [],
     "dictionaries": [],
     "words": [


### PR DESCRIPTION
## Description
VS Code was reporting both spelling errors (in `mkdocs.yml`) and schema problems (the `awesome-nav` plugin as invalid). This PR adds `mkdocs.yml` to the `cspell` ignore list and extends the Material for Mkdocs JSON schema to include `awesome-nav` as a valid plugin. This should result in there be zero reported problems in VS Code, therefore only genuine issues will be flagged.

## Related
#24 #38 

## Motivation and Context
VS Code flagging problems/spelling errors as false-positives means genuine problems can't be easily identified. This change should ensure that only real issues are flagged.

## How to review
* Review the `cspell.json` to verify that only the `mkdocs.yml` is excluded from spell checking.
* Review the `.vscode/settings.json` and custom schema file it references - this extends the existing Material for Mkdocs schema (rather than replace it) so that the original schema still applies.
* Load this branch in VS Code and check there are no spelling or linting issues reported.