### PR TITLE
Add missing TDA Actions and mark approved principles as such

### DIFF
--- a/doc/design-authority/dhcw/meetings/25-06-2025/index.md
+++ b/doc/design-authority/dhcw/meetings/25-06-2025/index.md
@@ -35,3 +35,5 @@ See [TDA 13/06/2025](../13-06-2025/index.md)
 | TDA-A009 | CL       | Form a Temporary Decision Group (TDG) to develop an Architecture Decision Record (ADR) and framework for the selection of Cloud provider for products and services |
 | TDA-A010 | RR       | Develop ways of working around API Delivery model for review |
 | TDA-A011 | All      | Review [Clinical Principles​](../../../../principles/clinical/index.md) for approval an next TDA |
+| TDA-A012 | CC       | Add Rationale and Implications to all principles for review |
+| TDA-A013 | CC       | Undertake holistic review of all principles and propose changes to make cohesive for review |

--- a/doc/principles/architecture-principles/index.md
+++ b/doc/principles/architecture-principles/index.md
@@ -1,8 +1,8 @@
 # Architecture Principles
 
-!!! warning
+!!! success "Approved"
 
-    Proposed changes to these principles are under review by the DHCW TDA
+    These principles have been approved by the DHCW TDA
 
 ## Deliver Sustainable Services
 

--- a/doc/principles/digital-products-and-software-engineering/index.md
+++ b/doc/principles/digital-products-and-software-engineering/index.md
@@ -1,8 +1,8 @@
 # Digital Products & Software Engineering Principles
 
-!!! warning
+!!! success "Approved"
 
-    These principles are not yet approved by the DHCW TDA
+    These principles have been approved by the DHCW TDA
 
 ## Introduction
 

--- a/doc/principles/index.md
+++ b/doc/principles/index.md
@@ -31,7 +31,7 @@ target timetable to compliance.
 
 These principles have been derived from the [NHS England Architecture Principles January 2021 v4](https://digital.nhs.uk/developer/architecture/principles).
 They also reflect the [Digital Service Standards for Wales](https://digitalpublicservices.gov.wales/guidance-and-standards/digital-service-standards-wales)
-published by the Centre for Digital Public Services.
+published by the [Centre for Digital Public Services](https://digitalpublicservices.gov.wales/).
 
 ## Approved Principles
 
@@ -40,26 +40,26 @@ Technical Design Authority (TDA):
 
 * [Architecture Principles](architecture-principles/index.md) - Our foundational
   principles that guide all architectural decisions
-* [Open Architecture & Integration](open-architecture/index.md) - Guidelines for
-  creating interoperable and extensible systems
-* [Digital Workplace](digital-workplace/index.md) - Principles for creating
-  effective digital working environments
-* [Data & Analytics](data-and-analytics/index.md) - Guidelines for data
-  management, analytics, and insights
 * [Cloud & Infrastructure](cloud-and-infrastructure/index.md) - Principles for
   cloud adoption and infrastructure design
+* [Data & Analytics](data-and-analytics/index.md) - Guidelines for data
+  management, analytics, and insights
+* [Digital Products & Software Engineering](digital-products-and-software-engineering/index.md) -
+  Best practices for building and maintaining digital products
+* [Digital Workplace](digital-workplace/index.md) - Principles for creating
+  effective digital working environments
+* [Open Architecture & Integration](open-architecture/index.md) - Guidelines for
+  creating interoperable and extensible systems
 * [Security & Identity](security-and-identity/index.md) - Core security and
   identity management principles
+* [User-Centred Design](user-centred-design/index.md) - Principles for creating
+  services that meet user needs
 
 ## Principles Under Development
 
 The following principles are currently being developed and reviewed. While not yet
 formally approved, they provide valuable guidance in their respective areas:
 
-* [User-Centred Design](user-centred-design/index.md) - Principles for creating
-  services that meet user needs
-* [Digital Products & Software Engineering](digital-products-and-software-engineering/index.md) -
-  Best practices for building and maintaining digital products
 * [Clinical Principles](clinical/index.md) - Guidelines for clinical systems
   and healthcare technology
 
@@ -78,5 +78,5 @@ and seek appropriate approval through the [Governance Process](../design-authori
 ## Contributing
 
 If you'd like to suggest changes to existing principles or propose new ones,
-please follow our [ADR process](../design-authority/dhcw/architecture-decision-record-process/index.md)
+please [Create an Issue](https://github.com/GIG-Cymru-NHS-Wales/architecture-decision-records/issues)
 and raise your proposal through the appropriate channels.

--- a/doc/principles/user-centred-design/index.md
+++ b/doc/principles/user-centred-design/index.md
@@ -1,8 +1,8 @@
 # User-Centred Design (UCD) Principles
 
-!!! Note
+!!! success "Approved"
 
-    These principles are not yet approved by the DHCW TDA
+    These principles have been approved by the DHCW TDA
 
 ## Start with user needs
 


### PR DESCRIPTION
## Description
Updated principles that were approved at the recent TDA to be marked as such and updated related pages to reflect this change.
Added some TDA actions that were missed in the previous update. 

## Related
#31 

## Motivation and Context
It's important that the principles reflect the correct status.

## How to review
* check the changes to the principles and related pages