### PR TITLE
feat: Add GitHub Actions workflow to convert ADR template to Word

### DIFF
--- a/.github/workflows/adr-template-to-word.yml
+++ b/.github/workflows/adr-template-to-word.yml
@@ -1,0 +1,47 @@
+# This workflow converts the ADR template to a Word document and publishes it as a release.
+name: ADR Template to Word
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'doc/design-authority/dhcw/architecture-decision-record-template.md'
+  workflow_dispatch:
+
+jobs:
+  convert-and-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get next version
+        id: get_version
+        run: |
+          # Get the latest tag
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0")
+          # Increment the version
+          version_number=$(echo $latest_tag | sed 's/v//')
+          next_version_number=$((version_number + 1))
+          echo "tag=v$next_version_number" >> $GITHUB_OUTPUT
+
+      - name: Set up Pandoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Convert Markdown to Word
+        run: |
+          pandoc doc/design-authority/dhcw/architecture-decision-record-template.md -o architecture-decision-record-template.docx
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.get_version.outputs.tag }}
+          name: ${{ steps.get_version.outputs.tag }}
+          files: architecture-decision-record-template.docx
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 .git/
-.github/
 .venv/
 site/


### PR DESCRIPTION
## Description
This commit introduces a new GitHub Actions workflow that automates the conversion of the Architecture Decision Record (ADR) template from Markdown to a Word document.

The workflow is triggered whenever the template file (`doc/design-authority/dhcw/architecture-decision-record-template.md`) is modified on the `main` branch or can be run manually

It uses Pandoc to perform the conversion and then creates a new GitHub Release, attaching the generated `.docx` file as a release asset. This ensures that an up-to-date Word version of the template is always available for download. The releases versions are automatically incremented as v1, v2, v3 etc.

This commit also removes the `.github/` directory from the `.gitignore` file, which was preventing the workflow from being tracked by Git.

## Motivation and Context
* Not everyone is able to easily work with Git and Markdown files, this will allow us to easily download Word document versions of the ADR template that can be shared and used by users.

## How to review
* Review the `.github/workflows/adr-template-to-word.yml` contents

-----
Co-authored-by: google-labs-jules[bot] <161369871+google-labs-jules[bot]@users.noreply.github.com>
