### PR TITLE
Fix immutable releases failing

### DIFF
--- a/.github/workflows/markdown-to-word.yml
+++ b/.github/workflows/markdown-to-word.yml
@@ -27,7 +27,7 @@ jobs:
           # Increment the version
           version_number=$(echo $latest_tag | sed 's/v//')
           next_version_number=$((version_number + 1))
-          echo "tag=v$next_version_number" >> $GITHUB_OUTPUT
+          echo "RELEASE_TAG=v$next_version_number" >> $GITHUB_ENV
 
       - name: Set up Pandoc
         run: |
@@ -37,13 +37,10 @@ jobs:
       - name: Convert Markdown to Word
         run: make word
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ steps.get_version.outputs.tag }}
-          name: ${{ steps.get_version.outputs.tag }}
-          files: |
-            architecture-decision-record-template.docx
-            architecture-design-overview-template.docx
+      - name: Publish Release
+        run: |
+          gh release create ${{ env.RELEASE_TAG }} --draft --generate-notes
+          gh release upload ${{ env.RELEASE_TAG }} architecture-decision-record-template.docx architecture-design-overview-template.docx
+          gh release edit ${{ env.RELEASE_TAG }} --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes creating a release now that GitHub has enabled [immutable releases ](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/immutable-releases) noting the 'softprops' GitHub Action doesn't support these yet (see https://github.com/softprops/action-gh-release/issues/653)